### PR TITLE
Fix GHC 7.6.3 build.

### DIFF
--- a/src/Control/Concurrent/Chan/Unagi/Bounded.hs
+++ b/src/Control/Concurrent/Chan/Unagi/Bounded.hs
@@ -1,11 +1,12 @@
 {-# LANGUAGE CPP #-}
-module Control.Concurrent.Chan.Unagi.Bounded (
+module Control.Concurrent.Chan.Unagi.Bounded
 #ifdef NOT_x86
     {-# WARNING "This library is unlikely to perform well on architectures without a fetch-and-add instruction" #-}
 #endif
 #if __GLASGOW_HASKELL__ < 708
     {-# WARNING "Waking up blocked writers may be slower than desired in GHC<7.8 which makes readMVar non-blocking on full MVars. Considering upgrading." #-}
 #endif
+    (
 {- | A queue with bounded size, which supports a 'writeChan' which blocks when
      the number of messages grows larger than desired. The bounds are
      maintained loosely between @n@ and @n*2@; see the caveats and descriptions


### PR DESCRIPTION
This one file had WARNING pragmas in a place where it doesn't seem to be allowed so the library did not build with GHC 7.6.3.
