### PR TITLE
Add estimatedLength for bounded queues

### DIFF
--- a/src/Control/Concurrent/Chan/Unagi/Bounded.hs
+++ b/src/Control/Concurrent/Chan/Unagi/Bounded.hs
@@ -22,6 +22,7 @@ module Control.Concurrent.Chan.Unagi.Bounded
     , tryReadChan
     , Element(..)
     , getChanContents
+    , estimatedLength
     -- ** Writing
     , writeChan
     , tryWriteChan


### PR DESCRIPTION
Adds an `estimatedLength` function for #23. 

Since the `InChan` constructors are not exported, I added `estimatedLength` into `Control.Concurrent.Chan.Unagi.Bounded.Internal` and exported it in `Control.Concurrent.Chan.Unagi.Bounded`.