### PR TITLE
Set more accurate lower bound on base

### DIFF
--- a/unagi-chan.cabal
+++ b/unagi-chan.cabal
@@ -79,7 +79,7 @@ library
                      , Data.Atomics.Counter.Fat
 
   ghc-options:        -Wall -funbox-strict-fields
-  build-depends:       base < 5
+  build-depends:       base >= 4.7 && < 5
                      , atomic-primops >= 0.8
                      , primitive>=0.5.3
                      , ghc-prim


### PR DESCRIPTION

...because of:

```
Configuring library for unagi-chan-0.4.1.0..
Preprocessing library for unagi-chan-0.4.1.0..
Building library for unagi-chan-0.4.1.0..
[ 1 of 14] Compiling Utilities        ( src/Utilities.hs, /tmp/matrix-worker/1534062100/dist-newstyle/build/x86_64-linux/ghc-7.6.3/unagi-chan-0.4.1.0/build/Utilities.o )

src/Utilities.hs:43:5:
    Not in scope: `tryReadMVar'
    Perhaps you meant one of these:
      `tryReadMVarIx' (line 42),
      `readMVar' (imported from Control.Concurrent.MVar)
<<ghc: 460867920 bytes, 816 GCs, 8625675/31060760 avg/max bytes residency (7 samples), 60M in use, 0.00 INIT (0.00 elapsed), 0.18 MUT (0.23 elapsed), 0.30 GC (0.32 elapsed) :ghc>>
```

In my function as Hackage Trustee I've already revised the affected releases at

 - https://hackage.haskell.org/package/unagi-chan-0.2.0.0/revisions/
 - https://hackage.haskell.org/package/unagi-chan-0.2.0.1/revisions/
 - https://hackage.haskell.org/package/unagi-chan-0.3.0.0/revisions/
 - https://hackage.haskell.org/package/unagi-chan-0.3.0.1/revisions/
 - https://hackage.haskell.org/package/unagi-chan-0.3.0.2/revisions/
 - https://hackage.haskell.org/package/unagi-chan-0.4.0.0/revisions/
 - https://hackage.haskell.org/package/unagi-chan-0.4.1.0/revisions/

See also https://matrix.hackage.haskell.org/package/unagi-chan